### PR TITLE
remove "index.html" from entries added to the menu

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -41,7 +41,7 @@
 					<ul>
 						{{ range .Site.Menus.main }}
 						<li class="page_item"> 
-							<a href="{{ .URL }}index.html">{{ .Name }}</a>
+							<a href="{{ .URL }}">{{ .Name }}</a>
 						</li>
 						{{ end }}
 					</ul>


### PR DESCRIPTION
the additional index.html suffix breaks external links that were added to the menu (see https://github.com/spf13/hugo/issues/1774#issuecomment-171704367)

Thought I'd give this change back to you, in case you'd like to have that. Thanks for the effort put into the theme!
